### PR TITLE
Use real site for OTX not corporate landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,7 +852,7 @@ Frameworks, platforms and services for collecting, analyzing, creating and shari
     </tr>
     <tr>
         <td>
-            <a href="https://www.alienvault.com/open-threat-exchange" target="_blank">OTX - Open Threat Exchange</a>
+            <a href="https://otx.alienvault.com" target="_blank">OTX - Open Threat Exchange</a>
         </td>
         <td>
             AlienVault Open Threat Exchange (OTX) provides open access to a global community of threat researchers and security professionals. It delivers community-generated threat data, enables collaborative research, and automates the process of updating your security infrastructure with threat data from any source.


### PR DESCRIPTION
The existing link was to the corporate landing page.  otx.alienvault.com is the actual threat exchange.