### PR TITLE
Add Cyberbro - Open source CTI observable search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,6 +1227,15 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/stanfrbd/cyberbro" target="_blank">Cyberbro</a>
+        </td>
+        <td>
+            Cyberbro is a self-hosted Python Flask application, also available as a Dockerized app, designed for effortless searching and reputation checking of observables. 
+            It extracts Indicators of Compromise (IoCs) from raw input and verifies their reputation using multiple services, custom APIs and scraping.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://cybergordon.com/" target="_blank">CyberGordon</a>
         </td>
         <td>


### PR DESCRIPTION
Hello,

Added Cyberbro, a Github project I develop, helping to analyze multiple observables with custom API and services.
It provides a comprehensive HTML report with filters and export options (CSV, auto-filtered excel file...)
This project can be self-hosted, using docker.

![image](https://github.com/user-attachments/assets/60c0ac9d-59c0-4d1f-bd52-29f8dcd7bd54)

I have read the rules.