### PR TITLE
Add certgrep and Have I Been Squatted tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1268,6 +1268,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://certgrep.sh" target="_blank">certgrep</a>
+        </td>
+        <td>
+            A fast Certificate Transparency Log regex domain lookup tool
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://cybergordon.com/" target="_blank">CyberGordon</a>
         </td>
         <td>
@@ -1320,6 +1328,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
         </td>
         <td>
             GoatRider is a simple tool that will dynamically pull down Artillery Threat Intelligence Feeds, TOR, AlienVaults OTX, and the Alexa top 1 million websites and do a comparison to a hostname file or IP file.
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <a href="https://haveibeensquatted.com" target="_blank">Have I Been Squatted</a>
+        </td>
+        <td>
+            A fast domain typosquatting detection tool
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
## Changes

This PR adds two new tools to the threat intelligence resources:

- **[certgrep](https://certgrep.sh)** - A fast Certificate Transparency Log regex domain lookup tool
- **[Have I Been Squatted](https://haveibeensquatted.com)** - A fast domain typosquatting detection tool

These tools are valuable additions for threat intelligence professionals working with domain analysis and certificate transparency logs.