### PR TITLE
Add Whisper - a free threat intelligence API from ex-ICANN/IETAdd Whisper - a free threat intelligence API from ex-ICANN/IETF folksF folksAdd Whisper to Sources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,14 @@ The primary goal of Malpedia is to provide a resource for rapid identification a
     </tr>
     <tr>
         <td>
+            <a href="https://whisper.security" target="_blank">Whisper</a>
+        </td>
+        <td>
+            Real-time graph intelligence platform that correlates 45 billion internet infrastructure data points. Built by former ICANN Board Director Kaveh Ranjbar and Soroush Rafiee Rad (double PhD in Math/InfoSec). Free API available at developer.whisper.security.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://github.com/Yara-Rules/rules" target="_blank">Yara-Rules</a>
         </td>
         <td>


### PR DESCRIPTION
Hi there,

I'd like to suggest adding Whisper to your list of threat intelligence sources.

It's a new real-time graph intelligence platform built by Kaveh Ranjbar (former ICANN Board Director, ran one of the 13 root servers) and Soroush Rafiee Rad (double PhD in Math/InfoSec). They're lifelong friends who have been deep in internet infrastructure for decades and wanted to build something that gives back to the community.

Whisper correlates 45 billion internet infrastructure data points and makes it accessible through a free API. The idea is to give threat hunters and analysts the context they need without the noise.

We'd love to get feedback from the threat intelligence community on how we can make it better. You can play with the free API here: https://developer.whisper.security

Thanks for considering it!