### PR TITLE
Add autosecure to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/vincentkoc/autosecure" target="_blank">autosecure</a>
+        </td>
+        <td>
+            Threat-feed IP block automation for Linux and macOS firewalls (<code>iptables</code>, <code>nftables</code>, <code>pf</code>), with scheduled updates and dry-run support.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://bitbucket.org/camp0/aiengine" target="_blank">AIEngine</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [autosecure](https://github.com/vincentkoc/autosecure), a threat-feed IP block automation tool for Linux and macOS firewalls (iptables, nftables, pf).