### PR TITLE
Add Pharos AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,14 @@ Frameworks, platforms and services for collecting, analyzing, creating and shari
     </tr>
     <tr>
         <td>
+            <a href="https://conflicts.app" target="_blank">Pharos AI</a>
+        </td>
+        <td>
+            Open-source real-time intelligence dashboard for conflict tracking. Aggregates 30+ OSINT feeds with geospatial visualization, actor dossiers, and event timelines. Self-hostable under AGPL-3.0.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://pulsedive.com/" target="_blank">Pulsedive</a>
         </td>
         <td>


### PR DESCRIPTION
Pharos AI is an open-source real-time intelligence dashboard for geopolitical conflict tracking.

- Live: https://conflicts.app
- Repo: https://github.com/Juliusolsson05/pharos-ai
- License: AGPL-3.0-only
- Stack: Next.js 16, React 19, PostgreSQL, DeckGL, MapLibre
- Self-hostable via Docker

It aggregates 30+ OSINT feeds (Reuters, AP, Press TV, TASS, etc.), provides interactive geospatial visualization, actor dossiers, event timelines, and daily intelligence briefs.