### PR TITLE
Add CrowdSec Blocklist Import to Tools section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: wolffcatskyy

--- a/README.md
+++ b/README.md
@@ -1260,6 +1260,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/wolffcatskyy/crowdsec-blocklist-import" target="_blank">crowdsec-blocklist-import</a>
+        </td>
+        <td>
+            A tool that aggregates 36+ free threat intelligence feeds (AbuseIPDB, Spamhaus, DShield, and more) into CrowdSec decisions, enabling centralized IP blocklist management. Supports daemon mode with scheduled updates, webhooks for real-time notifications, and Prometheus metrics for monitoring.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://cti-transmute.org/" target="_blank">CTI-Transmute</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [CrowdSec Blocklist Import](https://github.com/wolffcatskyy/crowdsec-blocklist-import) to the Tools section, in alphabetical order after CrowdFMS.

**About the project:**
- Imports threat intelligence from 36 free public blocklists into CrowdSec (FireHOL, Spamhaus, abuse.ch, Emerging Threats, etc.)
- Aggregates 120,000+ malicious IPs for use with any CrowdSec bouncer
- Docker-ready with Prometheus metrics and scheduled updates
- 180 stars, MIT licensed

The entry follows the existing HTML table format. Not a duplicate — the existing CrowdSec Console entry covers the SaaS console, while this tool focuses on importing third-party threat feeds into self-hosted CrowdSec deployments.