### PR TITLE
Add crowdsec-blocklist-import to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,6 +1260,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/wolffcatskyy/crowdsec-blocklist-import" target="_blank">crowdsec-blocklist-import</a>
+        </td>
+        <td>
+            A daemon that aggregates 36+ free threat intelligence blocklist feeds (including abuse.ch, Spamhaus, Emerging Threats, and others) into CrowdSec decisions. Features daemon mode with configurable intervals, webhook notifications, Prometheus metrics, and customizable feed management.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://cti-transmute.org/" target="_blank">CTI-Transmute</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [crowdsec-blocklist-import](https://github.com/wolffcatskyy/crowdsec-blocklist-import) to the Tools section.

**crowdsec-blocklist-import** is a daemon that aggregates 36+ free threat intelligence blocklist feeds (including abuse.ch, Spamhaus, Emerging Threats, and others) into CrowdSec decisions. It features:

- Daemon mode with configurable polling intervals
- Webhook notifications (Slack, Discord, generic)
- Prometheus metrics for monitoring
- Customizable feed management

The project has 185+ stars on GitHub and is actively maintained.