### PR TITLE
Add CyberBriefing — historical threat intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://cyberbriefing.info" target="_blank">CyberBriefing</a>
+        </td>
+        <td>
+            CyberBriefing provides an API for accessing 2.7M+ historical cybersecurity articles spanning 2007–2023, with full-text search, CVE/CVSS context, and AI-generated threat briefings. Free tier available; paid plans for higher rate limits and briefing generation.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://www.cybercure.ai/" target="_blank">Cyber Cure free intelligence feeds</a>
         </td>
         <td>


### PR DESCRIPTION
## Summary

Adds [CyberBriefing](https://cyberbriefing.info) to the Sources section.

**CyberBriefing** is a threat intelligence API and platform providing:
- **2.7M+ historical cybersecurity articles** spanning 2007–2023
- Full-text search with CVE/CVSS context
- AI-generated threat briefings tailored to industry and threat topic
- REST API with free tier; paid plans for higher throughput

**API docs**: https://cyberbriefing.info/docs

Fits well in Sources alongside other API-accessible threat intelligence services.