### PR TITLE
Add inframap - open-source CTI infrastructure attribution tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
             I-Blocklist maintains several types of lists containing IP addresses belonging to various categories. Some of these main categories include countries, ISPs and organizations. Other lists include web attacks, TOR, spyware and proxies. Many are free to use, and available in various formats.
         </td>
     </tr>
+	<tr>
+        <td>
+            <a href="https://github.com/rkbrainstorms/inframap" target="_blank">inframap</a>
+        </td>
+        <td>
+            Open-source infrastructure fingerprinting and attribution engine for CTI analysts. Chains 15 free sources (crt.sh, VirusTotal, ThreatFox, Shodan InternetDB, urlscan.io, passive DNS) into a single investigation workflow with auto-generated TLP:AMBER reports, MITRE ATT&CK mapping, and STIX 2.1 export. Zero external dependencies.
+        </td>
+    </tr>
     <tr>
         <td>
             <a href="https://raw.githubusercontent.com/stamparm/ipsum/master/ipsum.txt" target="_blank">IPsum</a>


### PR DESCRIPTION
inframap is an open-source infrastructure attribution engine for CTI analysts.

It chains 15 free data sources (crt.sh, VirusTotal, ThreatFox, Shodan InternetDB, 
urlscan.io, AbuseIPDB, Wayback Machine, passive DNS and more) into a single 
investigation workflow with auto-generated TLP:AMBER reports, MITRE ATT&CK mapping, 
and STIX 2.1 export.

- Zero external dependencies — pure Python stdlib
- MIT licensed
- CI tested on Python 3.8, 3.10, 3.12
- GitHub: https://github.com/rkbrainstorms/inframap