### PR TITLE
Add DFIR Platform to Frameworks and Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,14 @@ Frameworks, platforms and services for collecting, analyzing, creating and shari
     </tr>
     <tr>
         <td>
+            <a href="https://platform.dfir-lab.ch" target="_blank">DFIR Platform</a>
+        </td>
+        <td>
+            API-first threat intelligence platform aggregating 14+ sources for IOC enrichment, phishing email analysis, and exposure scanning. Includes AI-powered triage with MITRE ATT&CK mapping and detection rule generation. Free tier available.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://www.eclecticiq.com/platform" target="_blank">EclecticIQ Platform</a>
         </td>
         <td>


### PR DESCRIPTION
Adding [DFIR Platform](https://platform.dfir-lab.ch) to the Frameworks and Platforms section.

DFIR Platform is an API-first threat intelligence platform that aggregates 14+ sources for IOC enrichment (IPs, domains, hashes, URLs), phishing email forensics (26+ analysis modules), and external attack surface scanning (11 providers). It includes AI-powered triage with MITRE ATT&CK mapping and Sigma/YARA rule generation.

Credit-based pricing with a free tier (100 credits/month). Built in Switzerland.