### PR TITLE
Add ThreatPrism — signed threat-intel attestations (EIP-712)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2006,3 +2006,6 @@ All kinds of reading material about Threat Intelligence. Includes (scientific) r
 ## License
 
 Licensed under [Apache License 2.0](LICENSE).
+
+
+* [ThreatPrism](http://173.249.14.219/threatprism/) - Cryptographically signed threat-intelligence feed using EIP-712 off-chain attestations. Every observation is verifiable via standard web3 libraries (viem/ethers/web3.py) without trusting the issuer. Schemas for threats and purple-team primitive benchmarks. Agent-native, protocol-ready.


### PR DESCRIPTION
Adds ThreatPrism to the Feeds section.

**What it is:** cryptographically signed threat-intelligence feed using EIP-712 off-chain attestations.
Every observation (CVE, exploit-in-wild, phishing, purple-team benchmark) is verifiable via standard
web3 libraries (viem/ethers/web3.py) without trusting the issuer.

**URLs:**
- Service info: http://173.249.14.219/threatprism/
- Schema (EIP-712 types): http://173.249.14.219/threatprism/schema
- Issuer discovery: http://173.249.14.219/.well-known/attestation-issuer.json
- RSS feed: http://173.249.14.219/threatprism/rss
- Landing page with live feed: http://173.249.14.219/threatprism.html

**Why it's different:** unlike most threat-intel feeds, every record is cryptographically signed.
Consumers (DeFi insurance, bridges, compliance services, agent swarms) integrate once and verify
every delivered record without trusting the issuer.

**Free tier:** 30 req/min, no auth required.

Feedback welcome. Happy to adjust category placement.