### PR TITLE
Add Voidly — censorship threat intelligence with real-time alerts + CC BY 4.0 datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,14 @@ The primary goal of Malpedia is to provide a resource for rapid identification a
     </tr>
     <tr>
         <td>
+            <a href="https://voidly.ai" target="_blank">Voidly</a>
+        </td>
+        <td>
+            Internet-censorship threat intelligence aggregating OONI, CensoredPlanet and IODA measurements into citable incidents with evidence for network-layer attacks such as DNS poisoning, TCP reset injection, TLS interference and ISP-level blocking. Covers 19.6M measurements across 126 countries with a <a href="https://api.voidly.ai" target="_blank">public API</a>, real-time webhook alerts, RSS/Atom feeds, BibTeX/RIS citation export, and CC BY 4.0 datasets on <a href="https://huggingface.co/datasets/emperor-mew/global-censorship-index" target="_blank">HuggingFace</a>.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://vuldb.com/?actor" target="_blank">VulDB CTI</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [Voidly](https://voidly.ai) to `Sources`, inserted alphabetically in the V-block.

## Why censorship data is threat intelligence

Internet censorship events are network-layer attacks against service accessibility — the same primitives covered elsewhere in this list (DNS, TLS, BGP, ISP-scope indicators), just with state or ISP actors instead of criminal ones. Voidly aggregates three canonical measurement networks (OONI, CensoredPlanet, IODA) and detects concrete network-layer attack methods:

- **DNS poisoning / hijacking** (CensoredPlanet Satellite, 50 countries × ~35 domains)
- **TCP reset injection & middlebox manipulation** (OONI `http_invalid_request_line`, `http_header_field_manipulation`)
- **TLS interference and blockpages** (OONI `web_connectivity`)
- **ISP-level outages and route-withdrawals** (IODA ASN-level alerts)
- **Tor / messaging blocking** (OONI `tor`, `whatsapp`, `telegram`, `signal`)

These are observable, evidenced, IOC-grade indicators of hostile network behavior.

## What's in the entry

- **19.6M live OONI measurements**, 1.6M historical records (10-year archive), 126 countries
- **5,356 citable incidents** with human-readable IDs (`IR-2026-0142` format) + **16,822 evidence items**
- **Public API** at https://api.voidly.ai (no auth on public endpoints, CC BY 4.0)
- **Real-time webhook alerts** (HMAC-signed, exponential backoff) + RSS/Atom feeds for incidents
- **BibTeX / RIS citation export** per incident — built for research reuse
- Two CC BY 4.0 datasets on HuggingFace: [global-censorship-index](https://huggingface.co/datasets/emperor-mew/global-censorship-index) (live JSON) and [ooni-censorship-historical](https://huggingface.co/datasets/emperor-mew/ooni-censorship-historical) (1.6M Parquet)
- 37+ probe nodes globally testing 62 domains every 5 minutes

## Checklist

- [x] Not a duplicate (no existing OONI/CensoredPlanet/IODA/censorship entry in the list)
- [x] Single suggestion in a single PR
- [x] Matches the `<table>` formatting of neighboring entries
- [x] Useful PR/commit title

cc @hslatman — happy to trim the description if it runs long relative to neighbors, or move to a different section if `Sources` is the wrong home.