### PR TITLE
Add Voidly Censorship Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,14 @@ The primary goal of Malpedia is to provide a resource for rapid identification a
     </tr>
     <tr>
         <td>
+            <a href="https://voidly.ai/censorship-index" target="_blank">Voidly Censorship Index</a>
+        </td>
+        <td>
+            Real-time global internet censorship intelligence aggregating 19.6M live OONI samples and 1.6M historical records across 119+ countries. Provides a citable incident database (5,356 incidents, 16,822 evidence items), an ML-based shutdown early-warning feed (Sentinel), ISP-level risk scoring, and a public REST/MCP API for blocking, DNS poisoning, and BGP-level outage signals (CC BY 4.0).
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://github.com/Yara-Rules/rules" target="_blank">Yara-Rules</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [Voidly Censorship Index](https://voidly.ai/censorship-index) under **Sources**.

Voidly fits this list because it is a continuously updated, machine-readable threat-intel feed for nation-state and ISP-level network interference: 19.6M live OONI samples + 1.6M historical records across 119+ countries, surfaced as 5,356 citable incidents with 16,822 evidence items (DNS blocking, TCP-reset, blockpages, BGP-level outages). The data is CC BY 4.0 and exposed via REST + MCP, with an ML-driven shutdown early-warning model (Sentinel, AUC 0.98) for adversary-posture forecasting.

Entry placed alphabetically between **VulDB CTI** and **Yara-Rules** to match the existing Sources table format.

maintainer: @EmperorMew