### PR TITLE
Add Asia Fraud Info to Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
             A spreadsheet containing information and intelligence about APT groups, operations and tactics.
         </td>
     </tr>
-    <tr>
+           <tr>
+            <td>
+                <a href="https://asiafraudinfo.com/" target="_blank">Asia Fraud Info</a>
+            </td>
+            <td>
+                Asia Fraud Info delivers a searchable database of Asia-Pacific impersonation platforms — fake exchanges, fake brokers, romance-scam apps, and fake government portals — currently tracking 44+ platforms across 10 countries, with 31,000+ verified victim cases compiled from regulatory enforcement actions. The dataset is available with schema.org Dataset markup and 6 download distributions in 5 languages (EN/简体/繁體/日本語/한국어).
+            </td>
+        </tr>
+	<tr>
         <td>
             <a href="https://www.binarydefense.com/banlist.txt" target="_blank">Binary Defense IP Banlist</a>
         </td>


### PR DESCRIPTION
Adding Asia Fraud Info to the Sources section.

**What it provides**: A searchable Asia-Pacific anti-scam intelligence database tracking 44+ impersonation platforms (fake exchanges, fake brokers, romance-scam apps, fake government portals) across 10 countries, with 31,000+ verified victim cases compiled from regulatory enforcement actions and victim reports.

**Why it fits Sources**:
- Provides a list/dataset of threat actors (impersonation entities) — same category as PhishTank for phishing URLs, but focused on Asia-Pacific scam operations
- Cross-references regulatory advisories from HKMA, MAS, FSC Korea, JFSA, Taiwan FSC, ASIC, etc.
- Open dataset with schema.org `Dataset` markup + 6 download distributions
- 5-language coverage (EN / 简体 / 繁體 / 日本語 / 한국어)

**Format**:
- HTML `<table>` row matching the section's existing style
- Placed alphabetically between `APT Groups and Operations` and `Binary Defense IP Banlist`

**Links**:
- Main: https://asiafraudinfo.com/
- Open dataset: https://asiafraudinfo.com/data

Per `CONTRIBUTING.md`:
- ✅ Not a duplicate (verified: no Asia-Pacific scam-platform database currently in Sources)
- ✅ Individual PR for this single suggestion
- ✅ Adheres to the existing table formatting
- ✅ Useful title

Thanks for maintaining this list!