### PR TITLE
Add Domain Intelligence to Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://oti-labs.com/domain-intelligence-api" target="_blank">Domain Intelligence</a>
+        </td>
+        <td>
+            Single-call REST API aggregating DNS, WHOIS/RDAP, SSL/TLS, subdomain enumeration via Certificate Transparency logs (with DNS bruteforce fallback), and email-security posture (SPF/DMARC). Free tier; MIT-licensed open source.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://feed.ellio.tech" target="_blank">ELLIO: IP Feed (community free version)</a>
         </td>
         <td>


### PR DESCRIPTION
Adds Domain Intelligence to the Sources section.

Single-call REST API that aggregates DNS, WHOIS/RDAP, SSL/TLS certificate inspection, subdomain enumeration via Certificate Transparency logs (with DNS bruteforce fallback), and email-security posture (SPF/DMARC) into one response.

- Free tier (1,000 req/mo) via RapidAPI
- Public no-signup demo (5/IP/day) on the landing page: https://oti-labs.com/domain-intelligence-api
- Command-line: `curl https://oti-labs.com/demo/example.com | jq`
- Source: https://github.com/osiris-technical-institute/domain-intelligence-api (MIT)

Placed alphabetically between DNS Trails and ELLIO. Section fit: aggregated domain/IP intelligence data source, comparable to the existing DNS Trails / SecurityTrails entries.

Disclosure: I work on the project.