### PR TITLE
Add VoidAccess: self-hosted dark web threat intel platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1755,6 +1755,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
             The Threat Intelligence Quotient (TIQ) Test tool provides visualization and statistical analysis of TI feeds.
         </td>
     </tr>
+	<tr>
+    <td>
+        <a href="https://github.com/KatrielMoses/voidaccess" target="_blank">VoidAccess</a>
+    </td>
+    	<td>
+        VoidAccess is an open source self-hosted dark web OSINT platform for automated threat intelligence collection. Runs a 13-step pipeline over Tor covering query refinement, multi-engine search, entity extraction, relationship graphing, and structured export in STIX 2.1, MISP, Sigma, and CSV.
+    	</td>
+	</tr>
     <tr>
         <td>
             <a href="https://github.com/TAXIIProject/yeti" target="_blank">YETI</a>


### PR DESCRIPTION
Adding VoidAccess to the tools section.

Open-source, self-hosted dark web threat intelligence platform. Runs a 13-step automated pipeline over Tor — search, scrape, extract, enrich, graph, report. Enriches against 8 sources including OTX, ThreatFox, CISA KEV, MalwareBazaar, and Shodan. Exports STIX 2.1, MISP JSON, Sigma rules, and CSV.

MIT licensed. Runs on Docker with free LLM support via Groq, OpenRouter, or local Ollama.

GitHub: https://github.com/KatrielMoses/voidaccess