### PR TITLE
Add CVE PoC Search to the tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://labs.jamessawyer.co.uk/cves/" target="_blank">James Sawyer CVE PoC Search</a>
+        </td>
+        <td>
+            Search public GitHub proof-of-concept repositories by CVE identifier, with more than 30,000 CVEs indexed and daily updates.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://support.kaspersky.com/datafeeds" target="_blank">Kaspersky Threat Data Feeds</a>
         </td>
         <td>


### PR DESCRIPTION
Adds CVE PoC Search to the tools section as a searchable public resource for tracking GitHub proof-of-concept repositories by CVE identifier.

Link: https://labs.jamessawyer.co.uk/cves/