### PR TITLE
Add IP-API.io to Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://ip-api.io" target="_blank">IP-API.io</a>
+        </td>
+        <td>
+            IP-API.io provides IP intelligence for threat assessment: geolocation, ASN, reverse DNS, VPN, proxy and Tor exit node detection, IP reputation and risk scoring through a JSON API. Free tier of 200 lookups per day.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://ipasis.com" target="_blank">IPASIS</a>
         </td>
         <td>


### PR DESCRIPTION
Adds IP-API.io to the Sources section (alphabetically, between I-Blocklist and IPASIS; table formatting matches the existing rows).

IP-API.io is an IP intelligence API for threat assessment: geolocation, ASN, reverse DNS, VPN/proxy/Tor exit node detection, IP reputation and risk scoring in one JSON response. Free tier of 200 lookups/day; OpenAPI spec at https://ip-api.io/openapi.json, docs at https://ip-api.io/api-docs.html.

Disclosure: I run this service. Not affiliated with the similarly named ip-api.com. Not a duplicate — neither domain is currently in the list.