### PR TITLE
Add Darkfield to Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://darkfield.orizon.one" target="_blank">Darkfield</a>
+        </td>
+        <td>
+            A free public observatory of ransomware operators and their leak-site victim disclosures, blacklisted wallets, leaked credentials and dark web chatter. Every operator and victim has a permanent URL, and the collection methodology and limitations are documented publicly.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://dataplane.org/" target="_blank">DataPlane.org</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [Darkfield](https://darkfield.orizon.one) to the **Sources** section (alphabetised, before DataPlane.org), in the existing table format.

Darkfield is a free, no-signup observatory of the cybercrime ecosystem: ransomware operators and their leak-site victim disclosures, blacklisted wallets, leaked credentials and dark web chatter. Every operator and victim has a permanent URL, and the collection methodology and limitations are documented publicly: https://darkfield.orizon.one/methodology

- Not a duplicate (checked).
- Individual PR for this single suggestion.
- Follows the existing `<table>` row formatting.
- Useful title.