### PR TITLE
Add Superhighway - threat intelligence research agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1653,6 +1653,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://superhighway.walls.sh/guides/cybersecurity-research-agent" target="_blank">Superhighway</a>
+        </td>
+        <td>
+            Guide to building a Python threat-intelligence research agent that gathers CVE details, attacker TTPs, and IOCs from live web sources (advisories, NVD/MITRE pages, breach reports) and produces structured JSON reports with severity ratings, mitigation steps, and risk scores. Uses search, scrape, research, and news endpoints. Pay-per-call, no signup.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://stixvalidator.com" target="_blank">Stixvalidator.com</a>
         </td>
         <td>


### PR DESCRIPTION
Adds Superhighway's cybersecurity research agent guide to the **Tools** section (table format, alphabetical placement). The guide shows how to build a Python agent that researches CVEs, threat actors, and attack techniques using live web search — /search for advisories, /scrape for technical details from NVD/MITRE pages, /research for deep threat synthesis, /news for recent patches and breach reports. Outputs structured threat intelligence reports with severity ratings, IOCs, mitigation steps, and risk scores. Intended for defensive security research (SOC analysts, bug bounty hunters, threat modeling). Pay-per-call, no signup. Sits naturally next to AIOCRIOC and other web-scraping + LLM IOC tooling already on the list. https://superhighway.walls.sh/guides/cybersecurity-research-agent