### PR TITLE
Add AdversaryGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,14 @@ Frameworks, platforms and services for collecting, analyzing, creating and shari
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/anpa1200/adversarygraph" target="_blank">AdversaryGraph</a>
+        </td>
+        <td>
+            AdversaryGraph is a self-hosted CTI-to-detection workbench for mapping reports and IOCs to MITRE ATT&CK, correlating actors, campaigns and TTPs, enriching observables, and generating analyst-reviewed detection rules.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://www.cisa.gov/ais" target="_blank">AIS</a>
         </td>
         <td>

--- a/README.md
+++ b/README.md
@@ -830,7 +830,7 @@ Frameworks, platforms and services for collecting, analyzing, creating and shari
             <a href="https://github.com/anpa1200/adversarygraph" target="_blank">AdversaryGraph</a>
         </td>
         <td>
-            AdversaryGraph is a self-hosted CTI-to-detection workbench for mapping reports and IOCs to MITRE ATT&CK, correlating actors, campaigns and TTPs, enriching observables, and generating analyst-reviewed detection rules.
+            AdversaryGraph is a self-hosted CTI-to-detection workbench for mapping reports, IOCs, malware-analysis evidence, and operational telemetry to MITRE ATT&CK/ATLAS. It supports actor/campaign/TTP correlation, IOC enrichment, MalwareGraph-backed malware analysis, OpenCTI/STIX workflows, detection-gap review, analyst validation states, exports, and production-hardened Docker deployment.
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Adds AdversaryGraph to the Frameworks and Platforms section.

AdversaryGraph is a self-hosted CTI-to-detection workbench for mapping reports, IOCs, malware-analysis evidence, and operational telemetry to MITRE ATT&CK/ATLAS. It supports actor/campaign/TTP correlation, IOC enrichment, MalwareGraph-backed malware analysis, OpenCTI/STIX workflows, detection-gap review, analyst validation states, exports, and production-hardened Docker deployment.

Project links:
- Repository: https://github.com/anpa1200/adversarygraph
- Documentation: https://1200km.com/adversarygraph-docs/
- Live public workspace: https://1200km.com/threat-matrix/

Validation:
- README-only curated-list update.
- Upstream PR branch refreshed on 2026-06-27.
- AdversaryGraph production-readiness pass completed: backend tests 211 passed / 10 skipped, frontend lint/build passed, Docker Compose config validated.