### PR TITLE
Add BadBot to threat intelligence sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://badbot.net/" target="_blank">BadBot</a>
+        </td>
+        <td>
+            BadBot is an IP and domain reputation service using distributed honeypot sensors to score web/API abuse, exploit probes, credential-stuffing bots, and scanning activity. It provides correlation and high-risk feeds in JSON, CSV, and TXT formats.
+        </td>
+    </tr>
+
+	<tr>
+        <td>
             <a href="https://www.binarydefense.com/banlist.txt" target="_blank">Binary Defense IP Banlist</a>
         </td>
         <td>


### PR DESCRIPTION
Adds BadBot to the Sources section.

BadBot is an IP and domain reputation service backed by distributed honeypot sensors. It focuses on web/API scanning activity, credential-stuffing bots, exploit probes, exposed configuration probes, admin-panel probes, and related abuse.

The service provides time-decayed reputation scoring, abuse categories, indicator correlation, and downloadable high-risk feeds in JSON, CSV, and TXT formats.

This is submitted as a threat-intelligence source for defenders who want machine-readable IP/domain reputation data focused on web-facing infrastructure.