### PR TITLE
Add Malware Families Catalog dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://jordanricky1604-ship-it.github.io/malware-families-catalog/" target="_blank">Malware Families Catalog</a>
+        </td>
+        <td>
+            Open dataset of 2,899 malware families derived from EMBER 2018 with per-family MITRE ATT&CK techniques, IOCs, detection guidance, and incident response playbooks. Available as Parquet, JSONL, and a free JSON API. Apache-2.0 licensed.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://docs.google.com/spreadsheets/u/1/d/1H9_xaxQHpWaa4O_Son4Gx0YOIzlcBWMsdvePFX68EKU/pubhtml" target="_blank">APT Groups and Operations</a>
         </td>
         <td>

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,6 @@
+## Add Malware Families Catalog
+
+- **URL:** https://jordanricky1604-ship-it.github.io/malware-families-catalog/
+- **Description:** An expert-curated encyclopedia of 2,899 malware families. Features dynamic MITRE ATT&CK mappings, interactive incident response checklists, actionable IOCs, and is authored by Senior Incident Responders. Datasets available in Parquet/JSONL with a free JSON API.
+- **Mirrors:** [Kaggle](https://www.kaggle.com/datasets/rickyjordan/malware-families-catalog) | [Hugging Face](https://huggingface.co/datasets/Jordan123234/malware-families-catalog)
+- **License:** Apache-2.0


### PR DESCRIPTION
## Add Malware Families Catalog

- **URL:** https://jordanricky1604-ship-it.github.io/malware-families-catalog/
- **Description:** Open-source catalog of 2,899 malware families from EMBER 2018 with MITRE ATT&CK mapping, IOCs, detection guidance, and incident response playbooks.
- **Formats:** Parquet, JSONL, free JSON API
- **Mirrors:** [Kaggle](https://www.kaggle.com/datasets/rickyjordan/malware-families-catalog) | [Hugging Face](https://huggingface.co/datasets/Jordan123234/malware-families-catalog)
- **License:** Apache-2.0
