### PR TITLE
docs: add ThreatLens to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1675,6 +1675,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
             STIX Visualization Tool.
         </td>
     </tr>
+<tr>
+    <td>
+        <a href="https://github.com/AbdaullahAG/Threat_Intel_Project" target="_blank">ThreatLens</a>
+    </td>
+    <td>
+        ThreatLens is a professional multi-source Threat Intelligence CLI tool to investigate IPs, domains, hashes, and CVEs across 6 free APIs (AbuseIPDB, VirusTotal, AlienVault OTX, Shodan, URLScan.io, NVD) with automated log parsing and color-coded Excel/JSON reports. (Free for Non-commercial use).
+    </td>
+</tr>
     <tr>
         <td>
             <a href="https://test.taxiistand.com/" target="_blank">TAXII Test Server</a>


### PR DESCRIPTION
Hello! I would like to propose adding **ThreatLens** to the tools section.

**ThreatLens** is an open-source, modular CLI Threat Intelligence tool designed for SOC analysts and incident responders. It allows users to investigate multiple IOC types (IPs, Domains, Hashes, CVEs) across 6 free APIs simultaneously without switching tabs.

### Key Features:
* **Multi-source enrichment:** (AbuseIPDB, VirusTotal, Shodan, AlienVault OTX, URLScan, NVD).
* **Automated log parsing:** Extracts IOCs directly from raw text/log files.
* **Professional reporting:** Generates color-coded Excel, JSON, and CSV reports.
* **Robust Codebase:** Built with clean architecture, typed models, and full unit tests (`pytest`).

I have checked the contribution guidelines and ensured it adheres strictly to the existing two-column HTML table formatting and alphabetical order. Thank you for maintaining this awesome list!