### PR TITLE
Add CSIRTS.com to Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://www.csirts.com/" target="_blank">CSIRTS.com</a>
+        </td>
+        <td>
+            Free unified feed of official security advisories from 21 national CERTs, vendor PSIRTs and vulnerability databases (CISA, CERT-EU, CERT-Bund, CERT-FR, JPCERT/CC, MSRC, Cisco, Fortinet and more) — normalized into one schema, machine-translated to English, deduplicated and flagged against the CISA KEV catalog and public exploit datasets (Metasploit, Exploit-DB, Nuclei, PoC-in-GitHub). Keyless <a href="https://www.csirts.com/about" target="_blank">JSON API</a>, filterable RSS/Atom feeds, an <a href="https://www.csirts.com/mcp" target="_blank">MCP server</a> for AI agents and a daily email briefing.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://www.cybercure.ai/" target="_blank">Cyber Cure free intelligence feeds</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [CSIRTS.com](https://www.csirts.com) to the Sources section (alphabetical, before Cyber Cure).

CSIRTS.com is a free aggregator of official security advisories from 21 national CERTs, vendor PSIRTs and vulnerability databases (CISA + KEV, CERT-EU, CERT-Bund, CERT-FR, NCSC-NL, JPCERT/CC, JVN, HKCERT, CCCS, NVD, GHSA, MSRC, Cisco, Fortinet, Palo Alto Networks, GitLab, Jenkins, Drupal). Advisories are normalized into one schema, machine-translated to English, deduplicated across sources and cross-flagged against the CISA KEV catalog and four public exploit datasets (Metasploit, Exploit-DB, Nuclei templates, PoC-in-GitHub).

Programmatic access is free and keyless: JSON API with OpenAPI 3.1 spec, filterable RSS/Atom feeds (per source/severity/product/vendor/CVE/exploited), an MCP server for AI agents, and embeddable per-CVE status badges. Data refreshes every 3 hours; reuse is CC BY 4.0.

Disclosure: I run the project.