### PR TITLE
Add OSINTPRO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,6 +1572,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/haizen1312/osintpro" target="_blank">OSINTPRO</a>
+        </td>
+        <td>
+            Passive OSINT workspace for collecting public domain, username, repository and wallet evidence into investigation graphs and client-ready reports.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://github.com/kx499/ostip/wiki" target="_blank">OSTIP</a>
         </td>
         <td>


### PR DESCRIPTION
Adds OSINTPRO to the Tools section.\n\nOSINTPRO is a passive OSINT workspace for collecting public domain, username, repository and wallet evidence into investigation graphs and client-ready reports.\n\nDisclosure: I am related to the OSINTPRO project.