### PR TITLE
Add Cynative project information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1300,6 +1300,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/cynative/cynative" target="_blank">Cynative</a>
+        </td>
+        <td>
+            AI deep security research agent for cloud, code, and runtime environments across GitHub, GitLab, AWS, GCP, Azure, and Kubernetes, with read-only action gates, sandboxed code execution, evidence-backed verification, and audit logs.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://github.com/Neo23x0/Fenrir" target="_blank">Fenrir</a>
         </td>
         <td>

--- a/README.md
+++ b/README.md
@@ -1303,7 +1303,7 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
             <a href="https://github.com/cynative/cynative" target="_blank">Cynative</a>
         </td>
         <td>
-            AI deep security research agent for cloud, code, and runtime environments across GitHub, GitLab, AWS, GCP, Azure, and Kubernetes, with read-only action gates, sandboxed code execution, evidence-backed verification, and audit logs.
+            Open-source framework for security agents with live, read-only access to your infrastructure (connects to AWS, GCP, Azure, self-managed Kubernetes, GitHub and GitLab).
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Added Cynative: Open-source framework for security agents with live, read-only access to your infrastructure (connects to AWS, GCP, Azure, self-managed Kubernetes, GitHub and GitLab).