### PR TITLE
Add MalwareIntel to Frameworks and Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1524,6 +1524,15 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://malwareintel.es" target="_blank">MalwareIntel</a>
+        </td>
+        <td>
+            Free threat intelligence platform with 4,200+ malware families, 351K+ IOCs, MITRE ATT&CK mapping, 3,600+ detection rules, and browser-based security tools. Aggregates 117+ public feeds.
+        </td>
+    </tr>
+
+    <tr>
+        <td>
             <a href="https://github.com/MISP/misp-workbench" target="_blank">MISP Workbench</a>
         </td>
         <td>

--- a/README.md
+++ b/README.md
@@ -988,6 +988,14 @@ Frameworks, platforms and services for collecting, analyzing, creating and shari
     </tr>
     <tr>
         <td>
+            <a href="https://malwareintel.es" target="_blank">MalwareIntel</a>
+        </td>
+        <td>
+            MalwareIntel is a free threat intelligence platform that aggregates 13 public CTI feeds (Abuse.ch, AlienVault OTX, MITRE ATT&CK, CISA KEV, and more) into a single searchable interface. Features include IOC search across 1.6M+ indicators, malware family explorer with MITRE ATT&CK mapping, Sigma/KQL/SPL detection rule generator, and an interactive Knowledge Graph for visualizing threat relationships.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://www.fireeye.com/services/freeware.html" target="_blank">OpenIOC</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [MalwareIntel](https://malwareintel.es) to the Frameworks and Platforms section. Free CTI platform cataloguing 4,200+ malware families with IOCs, MITRE ATT&CK mapping, and 9 client-side security tools. Content in Spanish, adding linguistic diversity.