### PR TITLE
Add APTtrail to Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/trilwu/apttrail" target="_blank">APTtrail</a>
+        </td>
+        <td>
+            Hourly feed of ~167,000 APT indicators where every indicator carries the actor it belongs to, its MITRE ATT&CK group id, the date it first appeared and the report that published it. Available as a MISP feed, STIX 2.1, Suricata rules, Sigma, CSV and JSON.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://www.binarydefense.com/banlist.txt" target="_blank">Binary Defense IP Banlist</a>
         </td>
         <td>


### PR DESCRIPTION
Adds **APTtrail** to *Sources*, in alphabetical position between "APT Groups and
Operations" and "Binary Defense IP Banlist", following the existing table
formatting.

APTtrail is an hourly feed of ~167,000 APT indicators derived from Maltrail.
What distinguishes it from the other indicator sources already listed is that
attribution and provenance travel with each indicator rather than living
elsewhere:

- every indicator carries the actor it belongs to, and where MITRE tracks that
  actor, its `Gxxxx` id — 124 of 340 upstream groups resolve onto 97 ATT&CK
  intrusion sets, and the id survives into the Suricata, MISP and STIX output
- 167,134 of 167,135 indicators name the specific report that published them
- first-seen dates span 2015–2026, with 153,261 exact

Static files on stable URLs, no account or API key, rebuilt hourly. Available
as a MISP feed, STIX 2.1, Suricata rules with datasets, Sigma, CSV and JSON.

Site: https://trilwu.github.io/apttrail/
Source: https://github.com/trilwu/apttrail

Checked against the contribution guidelines: not a duplicate of an existing
entry, individual pull request, table formatting preserved (+8 lines, nothing
else touched).
