### PR TITLE
Add MalwareIntel to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1508,6 +1508,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://malwareintel.es" target="_blank">MalwareIntel</a>
+        </td>
+        <td>
+            Free threat intelligence platform with 4,200+ malware families, 351K+ IOCs, MITRE ATT&CK mapping, 3,600+ detection rules (Sigma, YARA, Snort), and browser-based security tools. Aggregates 117+ public feeds.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://github.com/silascutler/MalPipe" target="_blank">MalPipe</a>
         </td>
         <td>


### PR DESCRIPTION
MalwareIntel is a free threat intelligence platform for cybersecurity professionals.

- 4,200+ malware families with technical profiles
- 351,000+ IOCs (hash, IP, domain, URL)
- MITRE ATT&CK and D3FEND mapping
- 3,632 detection rules (Sigma, YARA, Snort)
- 117+ live feeds
- Knowledge Graph
- 9 browser-based tools (client-side, no data exfiltration)
- 590+ articles on malware analysis, DFIR, detection engineering

https://malwareintel.es