### PR TITLE
Add PulseFeed — security incident feed for the AI-agent payment economy (x402/MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://pulsefeed.dev/incidents" target="_blank">PulseFeed x402/MCP Security Feed</a>
+        </td>
+        <td>
+            Live security incidents in the x402 agent-payment economy and the MCP server ecosystem: hijacked payment receivers, bait-and-switch pricing, honeypots and unverified receivers, each with an on-chain proof URL. Free JSON (<a href="https://pulsefeed.dev/incidents.json" target="_blank">/incidents.json</a>) and RSS (<a href="https://pulsefeed.dev/incidents.rss" target="_blank">/incidents.rss</a>) feeds from a continuous independent audit; daily-updated dataset on <a href="https://huggingface.co/datasets/Nikolife/pulsefeed-x402-security" target="_blank">Hugging Face</a>.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://focsec.com" target="_blank">Focsec.com</a>
         </td>
         <td>

--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ The primary goal of Malpedia is to provide a resource for rapid identification a
             <a href="https://pulsefeed.dev/incidents" target="_blank">PulseFeed x402/MCP Security Feed</a>
         </td>
         <td>
-            Live security incidents in the x402 agent-payment economy and the MCP server ecosystem: hijacked payment receivers, bait-and-switch pricing, honeypots and unverified receivers, each with an on-chain proof URL. Free JSON (<a href="https://pulsefeed.dev/incidents.json" target="_blank">/incidents.json</a>) and RSS (<a href="https://pulsefeed.dev/incidents.rss" target="_blank">/incidents.rss</a>) feeds from a continuous independent audit; daily-updated dataset on <a href="https://huggingface.co/datasets/Nikolife/pulsefeed-x402-security" target="_blank">Hugging Face</a>.
+            Anomalies observed in live x402 payment endpoints and MCP servers: receiver-address changes between observations, catalog price vs. challenge price mismatches, invalid receivers, testnet endpoints listed as production and payment schemes outside the x402 spec — each with an on-chain reference. Measurements, not accusations of intent. Free JSON (<a href="https://pulsefeed.dev/incidents.json" target="_blank">/incidents.json</a>) and RSS (<a href="https://pulsefeed.dev/incidents.rss" target="_blank">/incidents.rss</a>) feeds from a continuous independent audit; daily-updated dataset on <a href="https://huggingface.co/datasets/Nikolife/pulsefeed-x402-security" target="_blank">Hugging Face</a>.
         </td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -157,14 +157,6 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
-            <a href="https://pulsefeed.dev/incidents" target="_blank">PulseFeed x402/MCP Security Feed</a>
-        </td>
-        <td>
-            Live security incidents in the x402 agent-payment economy and the MCP server ecosystem: hijacked payment receivers, bait-and-switch pricing, honeypots and unverified receivers, each with an on-chain proof URL. Free JSON (<a href="https://pulsefeed.dev/incidents.json" target="_blank">/incidents.json</a>) and RSS (<a href="https://pulsefeed.dev/incidents.rss" target="_blank">/incidents.rss</a>) feeds from a continuous independent audit; daily-updated dataset on <a href="https://huggingface.co/datasets/Nikolife/pulsefeed-x402-security" target="_blank">Hugging Face</a>.
-        </td>
-    </tr>
-    <tr>
-        <td>
             <a href="https://focsec.com" target="_blank">Focsec.com</a>
         </td>
         <td>
@@ -503,6 +495,14 @@ The primary goal of Malpedia is to provide a resource for rapid identification a
         </td>
         <td>
             PickupSTIX is a feed of free, open-source, and non-commercialized cyber threat intelligence. Currently, PickupSTIX uses three public feeds and distributes about 100 new pieces of intelligence each day. PickupSTIX translates the various feeds into STIX, which can communicate with any TAXII server. The data is free to use and is a great way to begin using cyber threat intelligence.
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <a href="https://pulsefeed.dev/incidents" target="_blank">PulseFeed x402/MCP Security Feed</a>
+        </td>
+        <td>
+            Live security incidents in the x402 agent-payment economy and the MCP server ecosystem: hijacked payment receivers, bait-and-switch pricing, honeypots and unverified receivers, each with an on-chain proof URL. Free JSON (<a href="https://pulsefeed.dev/incidents.json" target="_blank">/incidents.json</a>) and RSS (<a href="https://pulsefeed.dev/incidents.rss" target="_blank">/incidents.rss</a>) feeds from a continuous independent audit; daily-updated dataset on <a href="https://huggingface.co/datasets/Nikolife/pulsefeed-x402-security" target="_blank">Hugging Face</a>.
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Adds **PulseFeed x402/MCP Security Feed** to Sources (alphabetical position).

A new threat category is emerging as AI agents start paying for APIs autonomously (x402 protocol, HTTP 402 + USDC) and connecting to MCP servers: hijacked payment receivers (payTo swaps), bait-and-switch pricing, honeypot receivers, and MCP packages running arbitrary install scripts. PulseFeed continuously and independently audits both ecosystems (~5k x402 endpoints, 950+ MCP servers) and publishes incidents, each with an on-chain proof URL:

- JSON: https://pulsefeed.dev/incidents.json (also RSS: https://pulsefeed.dev/incidents.rss) — both return 200, no auth
- Methodology: https://pulsefeed.dev/methodology
- Daily-updated open dataset (CC-BY-4.0): https://huggingface.co/datasets/Nikolife/pulsefeed-x402-security

Free to read, no registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)