### PR TITLE
Add Threat Feed Me! to Frameworks and Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,14 @@ Frameworks, platforms and services for collecting, analyzing, creating and shari
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/alexlinos/threat-feed-me" target="_blank">Threat Feed Me!</a>
+        </td>
+        <td>
+            Self-hosted, on-prem aggregator that normalizes, deduplicates and confidence-scores free keyless IP blocklists into High/Medium/Low confidence tiers, served as ready-to-poll firewall feed URLs. Runs as a single Docker container (FastAPI + SQLite).
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://www.threatpipes.com" target="_blank">ThreatPipes</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [Threat Feed Me!](https://github.com/alexlinos/threat-feed-me) to the **Frameworks and Platforms** section (placed alphabetically after ThreatCrowd, matching the existing table format).

Threat Feed Me! is a free, open-source (MIT), self-hosted platform for collecting and operationalizing Threat Intelligence: it aggregates free keyless IP feeds, normalizes and deduplicates them, applies multi-factor confidence scoring into High/Medium/Low tiers, and serves the result as firewall-ready block-list URLs. Ships as a single Docker container (FastAPI + SQLite), no API keys required for the default feeds.