### PR TITLE
Add MalwareIntel - Free CTI Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,6 +964,14 @@ Frameworks, platforms and services for collecting, analyzing, creating and shari
     </tr>
     <tr>
         <td>
+            <a href="https://malwareintel.es" target="_blank">MalwareIntel</a>
+        </td>
+        <td>
+            Free CTI platform aggregating 4,300+ malware families and 1.8M+ IOCs from 117 public feeds. Features MITRE ATT&CK mapping with D3FEND mitigations, Sigma/YARA detection rules, interactive Knowledge Graph, and 600+ technical articles in Spanish. No installation required.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://github.com/CERT-Polska/n6" target="_blank">n6</a>
         </td>
         <td>


### PR DESCRIPTION
[MalwareIntel](https://malwareintel.es) is a free Cyber Threat Intelligence platform aggregating data from 117 public CTI feeds.

- 4,300+ malware families with MITRE ATT&CK mapping and D3FEND mitigations
- 1.8M+ IOCs (IPs, hashes, domains, URLs)
- 3,632 detection rules (Sigma + YARA)
- Interactive Knowledge Graph
- 600+ technical articles in Spanish
- 12 free browser-based security tools
- No registration, no installation, EU sovereign hosting