### PR TITLE
Add Fabrizio Salmi's Domains Blacklist to Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ A certain amount of (domain- or business-specific) analysis is necessary to crea
     </tr>
     <tr>
         <td>
+            <a href="https://github.com/fabriziosalmi/blacklists" target="_blank">Fabrizio Salmi's Domains Blacklist</a>
+        </td>
+        <td>
+            Daily-updated domain blocklist aggregated and de-duplicated from dozens of curated upstream sources, with per-source attribution and a public false-positive cross-check. Covers malware, phishing, advertising and tracking (and, from some upstream sources, gambling, piracy, streaming and adult domains). Published for Pi-hole, AdGuard, uBlock Origin, Squid, Unbound and RPZ (Bind/PowerDNS).
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://intercept.sh/threatlists/" target="_blank">FastIntercept</a>
         </td>
         <td>


### PR DESCRIPTION
Adds **Fabrizio Salmi's Domains Blacklist** to the **Sources** table (alphabetical position, between Exploitalert and FastIntercept), following CONTRIBUTING (individual PR, existing table formatting).

- Home: https://github.com/fabriziosalmi/blacklists
- A daily-updated domain blocklist aggregated and de-duplicated from dozens of curated upstream sources, with per-source attribution, verified licences and a public false-positive cross-check (~5M domains). Covers malware, phishing, advertising and tracking, plus gambling/piracy/streaming and adult domains from some upstream sources.
- Published in multiple formats (Pi-hole/AdGuard/uBO/Squid plain domains, Unbound, RPZ for Bind/PowerDNS); GPL-3.0.

Not a duplicate (verified absent from the current directory). Thanks for maintaining this list!