### PR TITLE
Add Malwagon - online malware analysis sandbox with IOC and STIX/MISP export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1516,6 +1516,14 @@ All kinds of tools for parsing, creating and editing Threat Intelligence. Mostly
     </tr>
     <tr>
         <td>
+            <a href="https://malwagon.com" target="_blank">Malwagon</a>
+        </td>
+        <td>
+            Malwagon is an online malware analysis sandbox that detonates files and URLs on instrumented Windows and Linux virtual machines. It returns process, registry, file and network behaviour, extracted indicators, ATT&amp;CK technique mappings and STIX and MISP exports, and it offers a REST API and a command line client. There is a free community tier to get started.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a href="https://github.com/MISP/misp-workbench" target="_blank">MISP Workbench</a>
         </td>
         <td>


### PR DESCRIPTION
Adds [Malwagon](https://malwagon.com) to the Tools section.

It detonates a submitted file or URL on instrumented Windows and Linux virtual machines and returns behavioural telemetry, extracted indicators, ATT&CK technique mappings and STIX and MISP exports, which is the threat-intelligence angle relevant to this list. A REST API and a command line client are available, and there is a free community tier.

Placed in alphabetical order between MalPipe and MISP Workbench, matching the existing table row markup. Single entry, single pull request, per the contribution guidelines. README_ch.md is left untouched.